### PR TITLE
Added more classes to exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,13 @@ import { IndexedDBChunkManager } from './IndexedDBChunkManager.js';
 import { IndexedDBNVD } from './IndexedDBNVD.js';
 import { WebClientTransceiver } from './WebClientTransceiver.js';
 
+export {
+	IndexedDBChunkManager,
+	IndexedDBNVD,
+	WebClientTransceiver,
+	BrowserCryptoManager,
+};
+
 function setupBasicCollectionTypes() {
     Collection.registerType('list', ChunkList);
     Collection.registerType('set', ChunkSet);


### PR DESCRIPTION
The modification was done due to other packages need access them, for instance the WebClientTransceiver can be used by React Native